### PR TITLE
Fixes huge flag in some QtWebEngine based browsers

### DIFF
--- a/src/components/index.jsx
+++ b/src/components/index.jsx
@@ -34,7 +34,8 @@ const IconButtonStyled = styled(IconButton)(({ theme }) => ({
   padding: 0,
   height: 30,
   '& svg': {
-    width: 'fill-available',
+    width: 'auto',
+    height: '1em',
   },
 }))
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1394828/169021251-f9086d1e-76bc-47fb-b7b4-64af8c3f7005.png)

Problem occurs in some QtWebEngine based browsers such as [qutebrowser](https://qutebrowser.org) or [Falkon](https://www.falkon.org).

This fixes it by restricting the height of the flag. Also changed the `width` because [`fill-available` is no longer a valid value](https://caniuse.com/?search=fill-available).

Also tested in Chrome and Firefox, which still look fine (just as before).